### PR TITLE
🐛 fix: Get captcha via Selenium screenshot instead of download

### DIFF
--- a/rarbg/captcha_handler.py
+++ b/rarbg/captcha_handler.py
@@ -10,10 +10,9 @@ class CaptchaHandler:
     def __init__(self):
         self.filename = 'solved_captcha.png'
 
-    def get_captcha(self, src):
-        img = requests.get(src)
+    def get_captcha(self, img_data):
         with open(self.filename, 'wb') as captcha_image:
-            captcha_image.write(img.content)
+            captcha_image.write(img_data)
         return self.solve_captcha(self.filename)
 
     @staticmethod

--- a/rarbg/middlewares.py
+++ b/rarbg/middlewares.py
@@ -77,8 +77,11 @@ class ThreatDefenceRedirectMiddleware(RedirectMiddleware):
         # Find
         captcha = self.driver.find_element_by_xpath("//img[contains(@src, 'captcha')]")
         LOGGER.info('Found CAPTCHA image: {0}'.format(captcha.get_attribute('src')))
+        image_data = captcha.screenshot_as_png
         # Solve
-        solved_captcha = self.captcha_handler.get_captcha(src=captcha.get_attribute('src'))
+        solved_captcha = self.captcha_handler.get_captcha(image_data)
+        if solved_captcha is None:
+            raise NoSuchElementException
         LOGGER.info('CAPTCHA solved: {0}'.format(solved_captcha))
         input_field = self.driver.find_element_by_id('solve_string')
         input_field.send_keys(solved_captcha)


### PR DESCRIPTION
Instead of attempting to download the captcha, use Selenium to get a
screenshot of the captcha element.

Fixes #1.